### PR TITLE
Add Slack integration for Zendesk tickets to post summary on slack channels for engineering help requests

### DIFF
--- a/SLACK_GUIDE.md
+++ b/SLACK_GUIDE.md
@@ -21,13 +21,12 @@ During setup, you'll be prompted for your Slack Bot Token and an optional defaul
    - Install the app to your workspace
    - Copy the "Bot User OAuth Token" (starts with `xoxb-`)
   
- 3.
-   - Add the bot to your channel:
-   - Open Slack
-   - Go to the channel where you want to post
-   - Right-click the channel and select "View channel details"
-   - Click "Integrations" tab
-   - Click "Add apps" and add your bot    
+ 3. Add the bot to your channel:
+    - Open Slack
+    - Go to the channel where you want to post
+    - Right-click the channel and select "View channel details"
+    - Click "Integrations" tab
+    - Click "Add apps" and add your bot    
 
 ## Posting to Slack
 

--- a/SLACK_GUIDE.md
+++ b/SLACK_GUIDE.md
@@ -1,0 +1,94 @@
+# Posting Zendesk Ticket Summaries to Slack
+
+## Setup
+
+1. First, make sure you've configured Lindesk with your Slack token:
+
+```bash
+lindesk setup
+```
+
+During setup, you'll be prompted for your Slack Bot Token and an optional default Slack channel.
+
+2. Create a Slack Bot in your workspace:
+   - Go to https://api.slack.com/apps
+   - Click "Create New App" and select "From scratch"
+   - Name your app (e.g., "Lindesk")
+   - Select your workspace
+   - Under "OAuth & Permissions", add these scopes:
+     - `chat:write`
+     - `chat:write.public`
+   - Install the app to your workspace
+   - Copy the "Bot User OAuth Token" (starts with `xoxb-`)
+
+## Posting to Slack
+
+### Basic Usage
+
+To post a Zendesk ticket summary to Slack:
+
+```bash
+lindesk transfer 12345 --channel C0123ABC456 --slack-only
+```
+
+Where:
+- `12345` is your Zendesk ticket ID
+- `C0123ABC456` is the Slack channel ID
+
+### Finding Your Slack Channel ID
+
+To get a channel ID:
+1. Open Slack in a browser
+2. Navigate to the channel
+3. The channel ID is in the URL: `https://app.slack.com/client/T0XXX/C0123ABC456`
+
+Or right-click on the channel in Slack and select "Copy Link" - the ID is at the end of the URL.
+
+### Using a Default Channel
+
+If you set a default channel during setup, you can omit the `--channel` parameter:
+
+```bash
+lindesk transfer 12345 --slack-only
+```
+
+### Posting to Multiple Channels
+
+To post to multiple channels, run the command multiple times:
+
+```bash
+lindesk transfer 12345 --channel C0123ABC456 --slack-only
+lindesk transfer 12345 --channel C9876XYZ123 --slack-only
+```
+
+### Creating Linear Issue and Posting to Slack
+
+To do both actions at once:
+
+```bash
+lindesk transfer 12345 --project ENG --channel C0123ABC456
+```
+
+## Slack Message Format
+
+The Slack message includes:
+- Ticket title
+- Problem summary
+- Impact assessment
+- Priority and complexity ratings
+- Link to the original Zendesk ticket
+
+## Troubleshooting
+
+If you encounter errors:
+
+1. Verify your Slack token is correct:
+   ```bash
+   lindesk setup
+   ```
+
+2. Ensure the bot has been added to the channel
+
+3. Check that the channel ID is correct
+
+4. Verify the bot has proper permissions in your Slack workspace

--- a/SLACK_GUIDE.md
+++ b/SLACK_GUIDE.md
@@ -21,13 +21,13 @@ During setup, you'll be prompted for your Slack Bot Token and an optional defaul
    - Install the app to your workspace
    - Copy the "Bot User OAuth Token" (starts with `xoxb-`)
   
- 3. 
-	1	Add the bot to your channel:
-	•	Open Slack
-	•	Go to the channel where you want to post
-	•	Right-click the channel and select "View channel details"
-	•	Click "Integrations" tab
-	•	Click "Add apps" and add your bot    
+ 3.
+   - Add the bot to your channel:
+   - Open Slack
+   - Go to the channel where you want to post
+   - Right-click the channel and select "View channel details"
+   - Click "Integrations" tab
+   - Click "Add apps" and add your bot    
 
 ## Posting to Slack
 

--- a/SLACK_GUIDE.md
+++ b/SLACK_GUIDE.md
@@ -20,6 +20,14 @@ During setup, you'll be prompted for your Slack Bot Token and an optional defaul
      - `chat:write.public`
    - Install the app to your workspace
    - Copy the "Bot User OAuth Token" (starts with `xoxb-`)
+  
+ 3. 
+	1	Add the bot to your channel:
+	•	Open Slack
+	•	Go to the channel where you want to post
+	•	Right-click the channel and select "View channel details"
+	•	Click "Integrations" tab
+	•	Click "Add apps" and add your bot    
 
 ## Posting to Slack
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -19,9 +19,16 @@ program
   .description('Transfer a Zendesk ticket to Linear with AI summary')
   .argument('<ticketId>', 'Zendesk ticket ID to transfer')
   .option('-p, --project <project>', 'Linear project key')
+  .option('-c, --channel <channel>', 'Slack channel ID to post summary to')
+  .option('--linear-only', 'Only create Linear issue, skip Slack')
+  .option('--slack-only', 'Only post to Slack, skip Linear')
   .action(async (ticketId, options) => {
     try {
-      await transferTicket(ticketId, options.project);
+      // Determine destination based on flags
+      const createLinear = !options.slackOnly;
+      const postToSlackChannel = !options.linearOnly && options.channel;
+      
+      await transferTicket(ticketId, options.project, options.channel, createLinear, postToSlackChannel);
     } catch (error) {
       console.error(chalk.red(`Error: ${error.message}`));
       process.exit(1);

--- a/src/commands/export-env.js
+++ b/src/commands/export-env.js
@@ -23,6 +23,13 @@ export async function exportEnv() {
   if (config.ampEndpoint && config.ampEndpoint !== 'https://ampcode.com/api/v1/chat/completions') {
     envContent += `AMP_ENDPOINT=${config.ampEndpoint}\n`;
   }
+  if (config.ampPath && config.ampPath !== 'amp') {
+    envContent += `AMP_PATH=${config.ampPath}\n`;
+  }
+  
+  // Add Slack config if available
+  if (config.slackToken) envContent += `SLACK_TOKEN=${config.slackToken}\n`;
+  if (config.defaultSlackChannel) envContent += `DEFAULT_SLACK_CHANNEL=${config.defaultSlackChannel}\n`;
   
   // Get the current working directory
   const cwd = process.cwd();
@@ -45,7 +52,7 @@ export async function exportEnv() {
     
     // Write the file
     await fs.writeFile(envFilePath, envContent);
-    console.log(chalk.green(`✓ Environment variables exported to ${envFilePath}`));
+    console.log(chalk.green(`u2713 Environment variables exported to ${envFilePath}`));
     console.log(chalk.gray('You can now use these environment variables automatically'));
   } catch (error) {
     console.error(chalk.red(`Error writing .env file: ${error.message}`));

--- a/src/commands/setup.js
+++ b/src/commands/setup.js
@@ -26,11 +26,27 @@ export async function setupConfig() {
   // Amp AI Configuration
   console.log('\n' + chalk.yellow('Amp AI Configuration:'));
   console.log(chalk.gray('Configure Amp AI for ticket analysis'));
+  console.log(chalk.blue('DEBUG: About to ask for Amp path'));
   
   const ampApiKey = await rl.question('Amp API key: ');
+  console.log(chalk.blue('DEBUG: Got Amp API key'));
   const ampEndpoint = await rl.question('Amp endpoint (optional, press Enter for default): ');
+  console.log(chalk.blue('DEBUG: Got Amp endpoint'));
+  const ampPath = await rl.question('Path to Amp CLI (e.g., /opt/homebrew/bin/amp or leave empty to use "amp" from PATH): ');
+  console.log(chalk.blue('DEBUG: Got Amp path: ' + ampPath));
   
   console.log(chalk.green('✓ Amp AI configured for ticket analysis'));
+  
+  // Slack Configuration
+  console.log('\n' + chalk.yellow('Slack Configuration:'));
+  console.log(chalk.gray('Configure Slack for posting ticket summaries'));
+  
+  const slackToken = await rl.question('Slack Bot Token: ');
+  const defaultSlackChannel = await rl.question('Default Slack channel ID (optional): ');
+  
+  if (slackToken) {
+    console.log(chalk.green('✓ Slack integration configured'));
+  }
   
   // Save configuration
   config.set('zendeskDomain', zendeskDomain);
@@ -41,9 +57,20 @@ export async function setupConfig() {
   if (ampEndpoint) {
     config.set('ampEndpoint', ampEndpoint);
   }
+  if (ampPath) {
+    config.set('ampPath', ampPath);
+  }
   
   if (defaultProject) {
     config.set('defaultProject', defaultProject);
+  }
+  
+  if (slackToken) {
+    config.set('slackToken', slackToken);
+  }
+  
+  if (defaultSlackChannel) {
+    config.set('defaultSlackChannel', defaultSlackChannel);
   }
   
   // Ask if user wants to generate .env file

--- a/src/commands/transfer.js
+++ b/src/commands/transfer.js
@@ -3,9 +3,10 @@ import { getConfig } from '../config.js';
 import { analyzeTicket } from '../services/ai-service.js';
 import { getZendeskTicket } from '../services/zendesk-service.js';
 import { createLinearIssue } from '../services/linear-service.js';
+import { postToSlack } from '../services/slack-service.js';
 import chalk from 'chalk';
 
-export async function transferTicket(ticketId, projectKey) {
+export async function transferTicket(ticketId, projectKey, slackChannel, createLinear = true, postToSlackChannel = false) {
   const config = getConfig();
   
   // Validate configuration
@@ -13,42 +14,91 @@ export async function transferTicket(ticketId, projectKey) {
     throw new Error('Zendesk credentials not configured. Run "lindesk setup" first.');
   }
   
-  if (!config.linearApiKey) {
+  if (createLinear && !config.linearApiKey) {
     throw new Error('Linear API key not configured. Run "lindesk setup" first.');
+  }
+  
+  if (postToSlackChannel && !config.slackToken) {
+    throw new Error('Slack token not configured. Run "lindesk setup" first.');
   }
   
   if (!config.ampApiKey) {
     throw new Error('Amp API key not configured. Run "lindesk setup" first.');
   }
   
-  // Use default project if not specified
-  const project = projectKey || config.defaultProject;
-  if (!project) {
-    throw new Error('No Linear project specified. Use --project option or set a default project.');
+  // Use default project if not specified for Linear
+  let project = null;
+  if (createLinear) {
+    project = projectKey || config.defaultProject;
+    if (!project) {
+      throw new Error('No Linear project specified. Use --project option or set a default project.');
+    }
   }
   
-  console.log(chalk.blue(`Transferring Zendesk ticket #${ticketId} to Linear...`));
+  // Use default channel if not specified for Slack
+  if (postToSlackChannel && !slackChannel) {
+    slackChannel = config.defaultSlackChannel;
+    if (!slackChannel) {
+      throw new Error('No Slack channel specified. Use --channel option or set a default channel.');
+    }
+  }
+  
+  // Determine what we're doing
+  let actionDescription = '';
+  if (createLinear && postToSlackChannel) {
+    actionDescription = `Processing Zendesk ticket #${ticketId} for Linear and Slack...`;
+  } else if (createLinear) {
+    actionDescription = `Transferring Zendesk ticket #${ticketId} to Linear...`;
+  } else if (postToSlackChannel) {
+    actionDescription = `Posting Zendesk ticket #${ticketId} summary to Slack...`;
+  }
+  
+  console.log(chalk.blue(actionDescription));
   
   // Step 1: Get the Zendesk ticket
   console.log(chalk.gray('Fetching ticket from Zendesk...'));
   const ticket = await getZendeskTicket(ticketId);
   console.log(chalk.green('✓ Zendesk ticket retrieved'));
+  if (ticket.organization) {
+    console.log(chalk.gray(`Organization: ${ticket.organization}`));
+  }
   
   // Step 2: Analyze ticket with Amp AI
   console.log(chalk.gray('Analyzing ticket with Amp AI...'));
   const analysis = await analyzeTicket(ticket);
   console.log(chalk.green('✓ Amp AI analysis complete'));
   
-  // Step 3: Create Linear issue
-  console.log(chalk.gray('Creating issue in Linear...'));
-  const issue = await createLinearIssue(analysis, project, ticketId);
-  console.log(chalk.green('✓ Linear issue created'));
+  let issue = null;
+  
+  // Step 3: Create Linear issue if requested
+  if (createLinear) {
+    console.log(chalk.gray('Creating issue in Linear...'));
+    issue = await createLinearIssue(analysis, project, ticketId);
+    console.log(chalk.green('✓ Linear issue created'));
+  }
+  
+  // Step 4: Post to Slack if requested
+  if (postToSlackChannel) {
+    console.log(chalk.gray(`Posting summary to Slack channel ${slackChannel}...`));
+    try {
+      // Pass the ticket organization explicitly to ensure it's available
+      await postToSlack(analysis, ticketId, slackChannel, ticket.organization);
+      console.log(chalk.green('✓ Posted to Slack successfully'));
+    } catch (error) {
+      console.warn(chalk.yellow(`Warning: Failed to post to Slack: ${error.message}`));
+    }
+  }
   
   // Success message
   console.log('');
-  console.log(chalk.green(`Successfully created Linear issue: ${issue.identifier} - ${issue.title}`));
-  console.log(chalk.blue(`Linear issue URL: ${issue.url}`));
-  console.log(chalk.gray(`Linked to Zendesk ticket #${ticketId}`));
+  if (createLinear && issue) {
+    console.log(chalk.green(`Successfully created Linear issue: ${issue.identifier} - ${issue.title}`));
+    console.log(chalk.blue(`Linear issue URL: ${issue.url}`));
+  }
+  if (postToSlackChannel) {
+    console.log(chalk.green(`Successfully posted summary to Slack channel ${slackChannel}`));
+  }
+  console.log(chalk.gray(`Referenced Zendesk ticket #${ticketId}`));
   
-  return issue;
+  return { issue, ticketId };
 }

--- a/src/config.js
+++ b/src/config.js
@@ -38,9 +38,21 @@ export const config = new Conf({
       type: 'string',
       default: process.env.AMP_ENDPOINT || 'https://ampcode.com/api/v1/chat/completions'
     },
+    ampPath: {
+      type: 'string',
+      default: process.env.AMP_PATH || 'amp'
+    },
     defaultProject: {
       type: 'string',
       default: process.env.DEFAULT_LINEAR_PROJECT || ''
+    },
+    slackToken: {
+      type: 'string',
+      default: process.env.SLACK_TOKEN || ''
+    },
+    defaultSlackChannel: {
+      type: 'string',
+      default: process.env.DEFAULT_SLACK_CHANNEL || ''
     }
   }
 });
@@ -53,6 +65,9 @@ export function getConfig() {
     linearApiKey: config.get('linearApiKey'),
     ampApiKey: config.get('ampApiKey'),
     ampEndpoint: config.get('ampEndpoint'),
-    defaultProject: config.get('defaultProject')
+    ampPath: config.get('ampPath'),
+    defaultProject: config.get('defaultProject'),
+    slackToken: config.get('slackToken'),
+    defaultSlackChannel: config.get('defaultSlackChannel')
   };
 }

--- a/src/services/slack-service.js
+++ b/src/services/slack-service.js
@@ -1,0 +1,157 @@
+import fetch from 'node-fetch';
+import { getConfig } from '../config.js';
+
+/**
+ * Posts a summary of a Zendesk ticket to a Slack channel
+ * @param {Object} analysis - The AI-generated analysis of the ticket
+ * @param {string} ticketId - The Zendesk ticket ID
+ * @param {string} teamChannel - The Slack channel ID to post to
+ * @param {string} organizationName - The organization name from Zendesk
+ * @returns {Promise<Object>} - The Slack message response
+ */
+export async function postToSlack(analysis, ticketId, teamChannel, organizationName) {
+  // Get access to the ticket for organization information
+  const ticket = analysis.ticket;
+  // Access the ticket info for organization data
+  const { slackToken, zendeskDomain } = getConfig();
+  
+  if (!slackToken) {
+    throw new Error('Slack token not configured. Run "lindesk setup" first.');
+  }
+
+  if (!teamChannel) {
+    throw new Error('Slack channel not specified. Use --channel option.');
+  }
+
+  // Use a simpler header for Slack
+  // Use the organization name passed directly from the transfer command
+  // Fall back to ticket data if available, otherwise use 'Customer'
+  const customerName = organizationName || ((ticket && ticket.organization) ? ticket.organization : 'Customer');
+  console.log('Using customer name for Slack message:', customerName);
+  
+  let slackBlocks = [
+    {
+      "type": "header",
+      "text": {
+        "type": "plain_text",
+        "text": `Need help with below support issue for ${customerName}`
+      }
+    },
+    {
+      "type": "divider"
+    },
+    {
+      "type": "actions",
+      "elements": [
+        {
+          "type": "button",
+          "text": {
+            "type": "plain_text",
+            "text": "View Zendesk Ticket"
+          },
+          "url": `https://${zendeskDomain}/agent/tickets/${ticketId}`
+        }
+      ]
+    }
+  ];
+
+  // Add the full analysis description as a series of message blocks
+  // Break the content into smaller chunks to fit Slack message limits
+  const fullDescription = analysis.description;
+  // Format the description for Slack
+
+  // Process the description to properly format Markdown for Slack
+  // Slack requires different markdown formatting
+  
+  // Remove the Engineering Recommendations section if present
+  let descriptionWithoutRecommendations = fullDescription;
+  const recommendationsRegex = /## Engineering Recommendations[\s\S]*?(?=## |$)/;
+  descriptionWithoutRecommendations = descriptionWithoutRecommendations.replace(recommendationsRegex, '');
+  
+  // Format for Slack
+  let processedDescription = descriptionWithoutRecommendations
+    .replace(/## ([^\n]+)/g, '*$1*') // Make headers bold
+    .replace(/\*\*/g, '*')         // Replace ** with * for bold
+    .replace(/\*\*/g, '*')         // Do it again to catch any remaining
+    .replace(/\n\n/g, '\n')       // Reduce excessive newlines
+    .trim();                     // Remove trailing whitespace
+  
+  // Split the description into chunks of approximately 3000 characters
+  // This ensures we stay under Slack's message size limits
+  const MAX_CHUNK_SIZE = 2800;
+  let startIndex = 0;
+  
+  while (startIndex < processedDescription.length) {
+    // Get the next chunk of text
+    const endIndex = Math.min(startIndex + MAX_CHUNK_SIZE, processedDescription.length);
+    let chunk = processedDescription.substring(startIndex, endIndex);
+    
+    // If we're in the middle of a line, try to end at a newline
+    if (endIndex < processedDescription.length) {
+      const lastNewline = chunk.lastIndexOf('\n');
+      if (lastNewline > 0 && lastNewline > MAX_CHUNK_SIZE - 500) {
+        chunk = chunk.substring(0, lastNewline);
+        startIndex += lastNewline + 1;
+      } else {
+        startIndex = endIndex;
+      }
+    } else {
+      startIndex = endIndex;
+    }
+    
+    // Add this chunk as a section
+    slackBlocks.push({
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": chunk
+      }
+    });
+  }
+  
+  // Post message to Slack
+  console.log('Posting to Slack channel...');
+  const response = await fetch('https://slack.com/api/chat.postMessage', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${slackToken}`
+    },
+    body: JSON.stringify({
+      channel: teamChannel,
+      blocks: slackBlocks
+    })
+  });
+
+  const data = await response.json();
+  
+  // Process API response
+
+  if (!data.ok) {
+    throw new Error(`Slack API error: ${data.error || JSON.stringify(data)}`);
+  }
+  
+  return data;
+}
+
+/**
+ * Extracts a section from the analysis description
+ * @param {string} description - The full ticket description
+ * @param {string} sectionName - The name of the section to extract
+ * @returns {string} - The extracted section text
+ */
+function extractSection(description, sectionName) {
+  if (!description) return "No information available";
+  
+  // Extract section with flexible pattern matching
+  
+  // More flexible regex that matches section headings with or without ## and variable whitespace
+  const sectionRegex = new RegExp(`(?:##\s*|\n)${sectionName}[:\s]*\n([\s\S]*?)(?=\n(?:##\s*|\n)[A-Za-z]|$)`, 'i');
+  const match = description.match(sectionRegex);
+  
+  if (match) {
+    return match[1].trim();
+  } else {
+    return "No information available";
+  }
+}


### PR DESCRIPTION
Added code to enable the app push tickets summaries to slack channels for engineering help and some small updates like explicitly setting AMP_PATH in case system face issues connecting to amp, like we can tune it to directly push it with all the details to discuss-cody, discuss-code search etc. Tested with my channel "testing2025".


